### PR TITLE
Remove duplicate entry in Info.plist

### DIFF
--- a/src/XamarinEvolve.iOS/Info.plist
+++ b/src/XamarinEvolve.iOS/Info.plist
@@ -50,8 +50,6 @@
 	<string>This app needs access to the camera to take photos.</string>
   	<key>NSRemindersUsageDescription</key>
 	<string>Add reminders for events.</string>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>This app needs access to photos.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>This app needs access to microphone.</string>
 	<key>UIApplicationShortcutItems</key>


### PR DESCRIPTION
It fails to build 
```
2017-09-21T20:51:15.6308420Z   /Library/Frameworks/Mono.framework/External/xbuild/Xamarin/iOS/Xamarin.iOS.Common.targets(1280,3): error MSB4018: The "IBTool" task failed unexpectedly. [/Users/xamarinqa/agent/_work/11/s/src/XamarinEvolve.iOS/XamarinEvolve.iOS.csproj]
2017-09-21T20:51:15.6321510Z /Library/Frameworks/Mono.framework/External/xbuild/Xamarin/iOS/Xamarin.iOS.Common.targets(1280,3): error MSB4018: System.ArgumentException: An item with the same key has already been added. Key: NSPhotoLibraryUsageDescription [/Users/xamarinqa/agent/_work/11/s/src/XamarinEvolve.iOS/XamarinEvolve.iOS.csproj]
```
https://devdiv.visualstudio.com/DevDiv/Xamarin%20QA/_build/index?buildId=1008280&_a=summary